### PR TITLE
Io cleanup check

### DIFF
--- a/swarmcg/swarmCG.py
+++ b/swarmcg/swarmCG.py
@@ -93,7 +93,7 @@ def read_ndx_atoms2beads(ns):
 		ndx_lines = [ndx_line.strip().split(';')[0] for ndx_line in ndx_lines]  # split for comments
 
 		ns.atoms_occ_total = collections.Counter()
-		ns.all_beadsall_beads = dict()  # atoms id mapped to each bead
+		ns.all_beads = dict()  # atoms id mapped to each bead
 		bead_id = 0
 		current_section = 'Beginning of file'
 

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -34,7 +34,7 @@ def test_read_itp():
 
 def test_read_cg_itp_file(ns_opt):
     # given:
-    required_tip_fields = ["real_beads_ids", "vs_beads_ids", "nb_bonds", "nb_angles",
+    required_itp_fields = ["real_beads_ids", "vs_beads_ids", "nb_bonds", "nb_angles",
                            "nb_dihedrals", "nb_constraints",
                            "moleculetype", "atoms", "constraint", "bond", "angle", "dihedral",
                            "virtual_sites2", "virtual_sites3", "virtual_sites4", "virtual_sitesn",
@@ -47,7 +47,7 @@ def test_read_cg_itp_file(ns_opt):
     # then:
     result = read_cg_itp_file(ns)
     assert isinstance(result, dict)
-    assert all([field in result for field in required_tip_fields])
+    assert all([field in result for field in required_itp_fields])
     check_ipt_dict(result)
 
     # when:


### PR DESCRIPTION
It passes my pycharm tests, except for virtual sites that I still need to correct + the reading of the masses is incorrect in some cases.

Masses can be present in the ITP of the molecule AND/OR in the ITP of the force field. Probably the masses that GMX uses are the ones present in the last #include in the TOP file.

For virtual sites, the main issues is that we need to consider that they are mapped in the NDX file, which is NOT the case atm. Then we need to act accordingly.